### PR TITLE
Fix the error in proportion calculation

### DIFF
--- a/vcf_minrep_filter_abs.py
+++ b/vcf_minrep_filter_abs.py
@@ -47,7 +47,7 @@ def num_in_pop_genotyped(record, indvs):
             count_genotyped += 1
         else:
             sys.exit('Unexpected value: {0}:{1}'.format(indiv, record.CHROM))
-    return int(count_genotyped)
+    return float(count_genotyped / (count_genotyped + count_missing))
 
 
 def prop_of_overall_genotyped(record, pops_indivs):


### PR DESCRIPTION
Changes in the threshold argument didn't modify outcomes because the function num_in_pop_genotyped returned an integer of the count of the number of individuals in which SNP was found, instead of the proportion of individuals in which an SNP was found.